### PR TITLE
bugfix/PP-13565: Checkout Displayed in English, Even Though the Language Is Specified in the API Request

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.payrexx.com?ref=wordpress
 Tags: payment, e-commerce, payrexx, gateway, postfinance, twint, wir, giropay, concardis, paymill, braintree, stripe, ogone, ingenico, viveum, reka, datatrans, six, saferpay, onepage, shop, payment link, invoices, virtual terminal, vpos
 Requires at least: 4.4
 Tested up to: 6.7
-Stable tag: 3.0.23
+Stable tag: 3.0.24
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -62,6 +62,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 4. Screenshot Payrexx Backend
 
 == Upgrade Notice ==
+
+= 3.0.24 =
+* Minor update, no need to backup
 
 = 3.0.23 =
 * New payment method update, no need to backup
@@ -359,6 +362,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 * First version of Payrexx plugin
 
 == Changelog ==
+
+= 3.0.24 =
+* Feature: Compatible with the Polylang plugin for gateway redirection.
 
 = 3.0.23 =
 * Feature: Added New payment method Pay by Bank.

--- a/src/Model/PaymentMethod/Abstract/Base.php
+++ b/src/Model/PaymentMethod/Abstract/Base.php
@@ -110,7 +110,7 @@ abstract class WC_Payrexx_Gateway_Base extends WC_Payment_Gateway
 		$order->update_meta_data('payrexx_gateway_id', $gateway->getId());
 		$order->save();
 
-		$language = substr(get_locale(), 0, 2);
+		$language = strtolower(substr(get_locale(), 0, 2));
 		!in_array($language, LANG) ? $language = LANG[0] : null;
 		$redirect = str_replace('?', $language . '/?', $gateway->getLink());
 

--- a/src/Model/PaymentMethod/Abstract/Base.php
+++ b/src/Model/PaymentMethod/Abstract/Base.php
@@ -110,7 +110,11 @@ abstract class WC_Payrexx_Gateway_Base extends WC_Payment_Gateway
 		$order->update_meta_data('payrexx_gateway_id', $gateway->getId());
 		$order->save();
 
-		$language = strtolower(substr(get_locale(), 0, 2));
+		if (isset($_COOKIE['pll_language'])) {
+			$language = sanitize_text_field($_COOKIE['pll_language']);
+		}
+		
+		$language = substr($language ?? get_locale(), 0, 2);
 		!in_array($language, LANG) ? $language = LANG[0] : null;
 		$redirect = str_replace('?', $language . '/?', $gateway->getLink());
 

--- a/woo-payrexx-gateway.php
+++ b/woo-payrexx-gateway.php
@@ -4,7 +4,7 @@
  * Description: Accept many different payment methods on your store using Payrexx
  * Author: Payrexx
  * Author URI: https://payrexx.com
- * Version: 3.0.23
+ * Version: 3.0.24
  * Requires at least: 4.4
  * Tested up to: 6.7
  * Requires Plugins: woocommerce
@@ -93,7 +93,7 @@ if (! class_exists( 'WC_Payrexx_Gateway' ))
 
 			define('PAYREXX_ADMIN_SETTINGS_ID' , 'payrexx');
 
-			define('LANG', ['en', 'de', 'it', 'fr', 'nl', 'pt', 'tr']);
+			define('LANG', ['en', 'de', 'it', 'fr', 'nl', 'pt', 'tr', ]);
 		}
 
 		protected function include() {

--- a/woo-payrexx-gateway.php
+++ b/woo-payrexx-gateway.php
@@ -93,7 +93,7 @@ if (! class_exists( 'WC_Payrexx_Gateway' ))
 
 			define('PAYREXX_ADMIN_SETTINGS_ID' , 'payrexx');
 
-			define('LANG', ['en', 'de', 'it', 'fr', 'nl', 'pt', 'tr', ]);
+			define('LANG', ['en', 'de', 'it', 'fr', 'nl', 'pt', 'tr']);
 		}
 
 		protected function include() {


### PR DESCRIPTION
The get_locale function always returns the language en. ie) It is the Worpress language default functionality, and other customers are not facing any issues.

The merchant uses the Polylang plugin to manage the languages on WordPress.

On WordPress, the order and payment process is done through Ajax. So the Polylang-provided function is not supported it returns an empty value.

**Solution:** I used a cookie for polylang to get the current language.