### PR TITLE
bugfix/PP-13882: WooCommerce Subscriptions Are Registered As Normal Transactions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.payrexx.com?ref=wordpress
 Tags: payment, e-commerce, payrexx, gateway, postfinance, twint, wir, giropay, concardis, paymill, braintree, stripe, ogone, ingenico, viveum, reka, datatrans, six, saferpay, onepage, shop, payment link, invoices, virtual terminal, vpos
 Requires at least: 4.4
 Tested up to: 6.7
-Stable tag: 3.0.24
+Stable tag: 3.0.25
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -62,6 +62,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 4. Screenshot Payrexx Backend
 
 == Upgrade Notice ==
+
+= 3.0.25 =
+* Minor update, no need to backup
 
 = 3.0.24 =
 * Minor update, no need to backup
@@ -362,6 +365,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 * First version of Payrexx plugin
 
 == Changelog ==
+
+= 3.0.25 =
+* Improvement: Improve the code to check for subscription products in the cart.
 
 = 3.0.24 =
 * Feature: Compatible with the Polylang plugin for gateway redirection.

--- a/src/Helper/SubscriptionHelper.php
+++ b/src/Helper/SubscriptionHelper.php
@@ -1,34 +1,38 @@
 <?php
 
 namespace PayrexxPaymentGateway\Helper;
-class SubscriptionHelper
-{
-    /**
-     * @param $cart
-     * @return bool
-     */
-    public static function isSubscription($cart)
-    {
-        if (empty($cart->cart_contents)) return false;
-        if (self::isPaymentMethodChange()) return true;
 
-        // Check if cart contains subscriptions
-        foreach ($cart->cart_contents as $cart_item) {
-            if (class_exists('WC_Subscriptions_Product') && \WC_Subscriptions_Product::is_subscription($cart_item['data'])) {
-                return true;
-            }
-        }
+class SubscriptionHelper {
+	/**
+	 * @param WC_Cart $cart
+	 * @return bool
+	 */
+	public static function isSubscription( $cart ): bool {
+		if ( empty( $cart ) || empty( $cart->get_cart() ) ) {
+			return false;
+		}
+		if ( self::isPaymentMethodChange() ) {
+			return true;
+		}
 
-        return false;
-    }
+		// Check if cart contains subscriptions
+		foreach ( $cart->get_cart() as $cart_item ) {
+			if ( class_exists( 'WC_Subscriptions_Product' ) && \WC_Subscriptions_Product::is_subscription( $cart_item['data'] ) ) {
+				return true;
+			}
+		}
 
-    /**
-     * @return bool
-     */
-    public static function isPaymentMethodChange():bool
-    {
-        $changePaymentMethod = !empty($_GET['change_payment_method']) ? $_GET['change_payment_method'] : null;
-        if (!$changePaymentMethod) return false;
-        return true;
-    }
+		return false;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public static function isPaymentMethodChange(): bool {
+		$changePaymentMethod = ! empty( $_GET['change_payment_method'] ) ? $_GET['change_payment_method'] : null;
+		if ( ! $changePaymentMethod ) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/woo-payrexx-gateway.php
+++ b/woo-payrexx-gateway.php
@@ -4,7 +4,7 @@
  * Description: Accept many different payment methods on your store using Payrexx
  * Author: Payrexx
  * Author URI: https://payrexx.com
- * Version: 3.0.24
+ * Version: 3.0.25
  * Requires at least: 4.4
  * Tested up to: 6.7
  * Requires Plugins: woocommerce


### PR DESCRIPTION

The customer is unable to confirm the recurring payment checkbox. 

The checkbox is not shown, and the subscription check functionality is not working.


Improved the code to check subscription products exist in the cart.