### PR TITLE
bugfix/PP-16526: WooCommerce Plugin Update Resulted in Error

### DIFF
--- a/woo-payrexx-gateway.php
+++ b/woo-payrexx-gateway.php
@@ -116,7 +116,9 @@ if (! class_exists( 'WC_Payrexx_Gateway' ))
 
 		protected function init() {
 			if (is_admin()) {
-				new WC_Payrexx_Gateway_Admin(__FILE__);
+                add_action( 'init', function() {
+				    new WC_Payrexx_Gateway_Admin(__FILE__);
+                });
 			}
 
 			$this->payrexxApiService = self::getPayrexxApiService();


### PR DESCRIPTION
Fixed the notice issue.

**Testcase:**

1. Enable debug mode in wp-config.php
```
define('WP_DEBUG', true);
define('WP_DEBUG_DISPLAY', true);
define( 'WP_DEBUG_LOG', true );
```
2. Log in to Backend.
3. The notice is not shown.
