### PR TITLE
bugfix/PP-19695: keep order completed when bank-transfer invoice mark…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.payrexx.com?ref=wordpress
 Tags: payment, e-commerce, credit card, payrexx, gateway
 Requires at least: 5.6
 Tested up to: 6.9
-Stable tag: 3.1.17
+Stable tag: 3.1.18
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 3. Payrexx backend integration
 
 == Upgrade Notice ==
+
+= 3.1.18 =
+* Minor update, no need to backup
 
 = 3.1.17 =
 * New platform update, no need to backup
@@ -444,6 +447,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 * First version of Payrexx plugin
 
 == Changelog ==
+
+= 3.1.18 =
+* PP-19695: Bank transfer (Payrexx Pay) invoices manually marked as paid now complete the WooCommerce order instead of cancelling it.
 
 = 3.1.17 =
 * Feature: Added Naka to Platform selection

--- a/src/Webhook/Dispatcher.php
+++ b/src/Webhook/Dispatcher.php
@@ -10,6 +10,9 @@ use PayrexxPaymentGateway\Util\StatusUtil;
 
 class Dispatcher
 {
+    const BRAND_BANK_TRANSFER = 'bank-transfer';
+    const PSP_NATIVE = 'Native_PSP';
+
     /**
      * @var PayrexxApiService
      */
@@ -111,6 +114,18 @@ class Dispatcher
                 $refundedAmount = StatusUtil::getAmountByStatusAndGateway($gateway, [Transaction::PARTIALLY_REFUNDED, Transaction::REFUNDED]);
 
                 $newTransactionStatus = StatusUtil::determineNewOrderStatus($orderTotal, $confirmedAmount, $refundedAmount);
+            }
+
+            // Marking a Payrexx Pay bank transfer invoice as paid in the merchant backend cancels the open
+            // waiting transaction, which would otherwise cancel an already paid order. Treat it as confirmed.
+            $payment = $transaction->getPayment();
+            if ($newTransactionStatus === Transaction::CANCELLED
+                && is_array($payment)
+                && ($payment['brand'] ?? '') === self::BRAND_BANK_TRANSFER
+                && $transaction->getPsp() === self::PSP_NATIVE
+                && in_array(($payment['invoicePaymentStatus'] ?? null), ['paid', 'overpaid'], true)
+            ) {
+                $newTransactionStatus = Transaction::CONFIRMED;
             }
 
             $transactionUuid = $transaction->getUuid();

--- a/woo-payrexx-gateway.php
+++ b/woo-payrexx-gateway.php
@@ -4,7 +4,7 @@
  * Description: Accept many different payment methods on your store using Payrexx
  * Author: Payrexx
  * Author URI: https://payrexx.com
- * Version: 3.1.17
+ * Version: 3.1.18
  * Requires at least: 5.6
  * Tested up to: 6.9
  * Requires PHP: 8.0


### PR DESCRIPTION
For Payrexx Pay bank-transfer invoices (brand = bank-transfer, psp = Native_PSP), two different merchant actions in the Payrexx backend fire the same transaction cancelled webhook:
Mark as paid (merchant received the money, e.g. cash/bank) → the invoice becomes paid, but the open waiting transaction is cancelled.

Cancel → the invoice stays waiting/unpaid and the order should remain cancelled.
Bank-transfer order → Mark as paid → WooCommerce order → completed/processing ✅
Bank-transfer order → Cancel → WooCommerce order → cancelled ✅
Payrexx transaction stays cancelled in both cases → no double payout.