### PR TITLE
bugfix/PP-19798: Woocommerce Gateway Cancels Subscriptions on Declined Payments

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.payrexx.com?ref=wordpress
 Tags: payment, e-commerce, credit card, payrexx, gateway
 Requires at least: 5.6
 Tested up to: 7.0
-Stable tag: 3.1.19
+Stable tag: 3.1.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -450,6 +450,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 * First version of Payrexx plugin
 
 == Changelog ==
+
+= 3.1.20 =
+* PP-19798: Failed subscription payments are now marked as failed instead of cancelled across the webhook, redirect and timeout paths.
 
 = 3.1.19 =
 * PP-19695: Bank transfer (Payrexx Pay) invoices manually marked as paid now complete the WooCommerce order instead of cancelling it.

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,9 @@ payment methods especially in Europe that you can quickly and easily integrate i
 
 == Upgrade Notice ==
 
+= 3.1.20 =
+* Minor update, no need to backup
+
 = 3.1.19 =
 * Minor update, no need to backup
 

--- a/src/Helper/PaymentHelper.php
+++ b/src/Helper/PaymentHelper.php
@@ -24,9 +24,12 @@ class PaymentHelper
 
 		$orderService = WC_Payrexx_Gateway::getOrderService();
 
-		// Set order status to cancelled
-		if ( $orderService->transition_allowed( OrderService::WC_STATUS_CANCELLED, $order ) ) {
-			$orderService->transitionOrder( $order, OrderService::WC_STATUS_CANCELLED );
+		// Subscription orders: 'failed' keeps the WCS subscription on-hold instead of cancelling it permanently.
+		$order_status = $orderService->orderContainsSubscription( $order )
+			? OrderService::WC_STATUS_FAILED
+			: OrderService::WC_STATUS_CANCELLED;
+		if ( $orderService->transition_allowed( $order_status, $order ) ) {
+			$orderService->transitionOrder( $order, $order_status );
 		}
 
 		$payrexxApiService = WC_Payrexx_Gateway::getPayrexxApiService();

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -72,9 +72,14 @@ class OrderService
 				);
 				return;
 			case Transaction::CANCELLED:
+				$order_status = self::WC_STATUS_CANCELLED;
+				break;
 			case Transaction::EXPIRED:
 			case Transaction::DECLINED:
-				$order_status = self::WC_STATUS_CANCELLED;
+				// Retryable failure: 'failed' keeps a WCS subscription on-hold (retry), 'cancelled' would end it permanently.
+				$order_status = $this->orderContainsSubscription( $order )
+					? self::WC_STATUS_FAILED
+					: self::WC_STATUS_CANCELLED;
 				break;
 			case Transaction::ERROR:
 				$order_status = self::WC_STATUS_FAILED;
@@ -85,6 +90,17 @@ class OrderService
 		}
 
 		$this->transitionOrder( $order, $order_status, $transaction_uuid );
+	}
+
+	/**
+	 * Check whether the order belongs to a WooCommerce subscription
+	 *
+	 * @param WC_Order $order woocommerce order.
+	 * @return bool
+	 */
+	public function orderContainsSubscription( $order ): bool {
+		return function_exists( 'wcs_order_contains_subscription' )
+			&& wcs_order_contains_subscription( $order, 'any' );
 	}
 
 	/**

--- a/tests/OrderServiceStatusMappingTest.php
+++ b/tests/OrderServiceStatusMappingTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PP-19798 — Status mapping in OrderService::handleTransactionStatus().
+ *
+ * DECLINED/EXPIRED are retryable failures. For orders that belong to a
+ * subscription they must map to WC 'failed' (WCS: subscription on-hold +
+ * retry) instead of 'cancelled' (WCS: permanent cancellation). Non-subscription
+ * orders keep the previous behaviour (cancelled → WC core releases stock again;
+ * 'failed' has no increase-stock hook).
+ *
+ * Standalone like DispatcherBankTransferStatusTest.php (the plugin has no
+ * PHPUnit infrastructure). Unlike that test, the REAL class is invoked here —
+ * the WP/WCS coupling is covered via function stubs.
+ *
+ * Run:
+ *   php tests/OrderServiceStatusMappingTest.php
+ */
+
+use Payrexx\Models\Response\Transaction;
+use PayrexxPaymentGateway\Service\OrderService;
+
+/* ------------------------------------------------------------ WP/WCS stubs */
+
+$GLOBALS['px_test_order_has_subscription'] = false;
+
+function wp_clear_scheduled_hook($hook, $args = [])
+{
+}
+
+function apply_filters($tag, $value)
+{
+    return $value;
+}
+
+function __($text, $domain = 'default')
+{
+    return $text;
+}
+
+function wcs_order_contains_subscription($order, $order_type = 'parent')
+{
+    return $GLOBALS['px_test_order_has_subscription'];
+}
+
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../src/Service/OrderService.php';
+
+/* -------------------------------------------------------------- Fake order */
+
+class FakeOrder
+{
+    public ?string $updated_status = null;
+    public array $notes = [];
+    private string $status;
+    private string $transaction_id;
+
+    public function __construct(string $status = 'pending', string $transaction_id = '')
+    {
+        $this->status = $status;
+        $this->transaction_id = $transaction_id;
+    }
+
+    public function get_id()
+    {
+        return 42;
+    }
+
+    public function get_status()
+    {
+        return $this->status;
+    }
+
+    public function get_transaction_id()
+    {
+        return $this->transaction_id;
+    }
+
+    public function get_total($context = 'view')
+    {
+        return '18.00';
+    }
+
+    public function add_order_note($note)
+    {
+        $this->notes[] = $note;
+    }
+
+    public function update_status($status, $note = '')
+    {
+        $this->updated_status = $status;
+        $this->status = $status;
+    }
+}
+
+function runStatus(string $payrexx_status, bool $hasSubscription, string $orderStatus = 'pending'): FakeOrder
+{
+    $GLOBALS['px_test_order_has_subscription'] = $hasSubscription;
+    $order = new FakeOrder($orderStatus);
+    (new OrderService())->handleTransactionStatus($order, [], $payrexx_status, 'test-uuid');
+
+    return $order;
+}
+
+/* ---------------------------------------------------------------- Mini runner */
+
+$passed = 0;
+$failed = 0;
+
+/** @param callable():void $fn */
+function test(string $name, callable $fn): void
+{
+    global $passed, $failed;
+    try {
+        $fn();
+        $passed++;
+        echo "  PASS  $name\n";
+    } catch (\Throwable $e) {
+        $failed++;
+        echo "  FAIL  $name\n        -> {$e->getMessage()}\n";
+    }
+}
+
+function assertSame($expected, $actual, string $msg = ''): void
+{
+    if ($expected !== $actual) {
+        $e = var_export($expected, true);
+        $a = var_export($actual, true);
+        throw new \RuntimeException(($msg ? $msg . ' — ' : '') . "expected $e, got $a");
+    }
+}
+
+/* ------------------------------------------------------------------- Test cases */
+
+echo "PP-19798 OrderService status mapping (subscription-scoped)\n";
+
+// Bug case: DECLINED/EXPIRED + subscription -> failed (WCS: on-hold + retry)
+test('DECLINED + subscription order => FAILED (bugfix)', function () {
+    $order = runStatus(Transaction::DECLINED, true);
+    assertSame(OrderService::WC_STATUS_FAILED, $order->updated_status);
+});
+test('EXPIRED + subscription order => FAILED (bugfix)', function () {
+    $order = runStatus(Transaction::EXPIRED, true);
+    assertSame(OrderService::WC_STATUS_FAILED, $order->updated_status);
+});
+
+// Deliberate abort stays cancelled — even for a subscription
+test('CANCELLED + subscription order => stays CANCELLED', function () {
+    $order = runStatus(Transaction::CANCELLED, true);
+    assertSame(OrderService::WC_STATUS_CANCELLED, $order->updated_status);
+});
+
+// Non-subscription orders: current behaviour unchanged (stock release via cancelled)
+test('DECLINED + normal order => stays CANCELLED (no behaviour change)', function () {
+    $order = runStatus(Transaction::DECLINED, false);
+    assertSame(OrderService::WC_STATUS_CANCELLED, $order->updated_status);
+});
+test('EXPIRED + normal order => stays CANCELLED (no behaviour change)', function () {
+    $order = runStatus(Transaction::EXPIRED, false);
+    assertSame(OrderService::WC_STATUS_CANCELLED, $order->updated_status);
+});
+test('CANCELLED + normal order => stays CANCELLED', function () {
+    $order = runStatus(Transaction::CANCELLED, false);
+    assertSame(OrderService::WC_STATUS_CANCELLED, $order->updated_status);
+});
+
+// Regression: ERROR mapping unchanged
+test('ERROR + normal order => FAILED (as before)', function () {
+    $order = runStatus(Transaction::ERROR, false);
+    assertSame(OrderService::WC_STATUS_FAILED, $order->updated_status);
+});
+test('ERROR + subscription order => FAILED (as before)', function () {
+    $order = runStatus(Transaction::ERROR, true);
+    assertSame(OrderService::WC_STATUS_FAILED, $order->updated_status);
+});
+
+// Regression: transition_allowed gate still applies (failed only from pending/on-hold)
+test('DECLINED + subscription + order already processing => no status change', function () {
+    $order = runStatus(Transaction::DECLINED, true, 'processing');
+    assertSame(null, $order->updated_status);
+});
+test('DECLINED + subscription + order on-hold => FAILED (allowed transition)', function () {
+    $order = runStatus(Transaction::DECLINED, true, 'on-hold');
+    assertSame(OrderService::WC_STATUS_FAILED, $order->updated_status);
+});
+
+// Regression: WAITING unchanged -> on-hold
+test('WAITING + subscription order => ON-HOLD (as before)', function () {
+    $order = runStatus(Transaction::WAITING, true);
+    assertSame(OrderService::WC_STATUS_ONHOLD, $order->updated_status);
+});
+
+/* --------------------------------------------------------------------- Output */
+
+echo "\n$passed passed, $failed failed\n";
+exit($failed === 0 ? 0 : 1);

--- a/woo-payrexx-gateway.php
+++ b/woo-payrexx-gateway.php
@@ -4,7 +4,7 @@
  * Description: Accept many different payment methods on your store using Payrexx
  * Author: Payrexx
  * Author URI: https://payrexx.com
- * Version: 3.1.19
+ * Version: 3.1.20
  * Requires at least: 5.6
  * Tested up to: 7.0
  * Requires PHP: 8.0

--- a/woo-payrexx-gateway.php
+++ b/woo-payrexx-gateway.php
@@ -340,6 +340,15 @@ if (! class_exists( 'WC_Payrexx_Gateway' ))
 				return;
 			}
 
+			// Subscription orders: 'failed' keeps the WCS subscription on-hold instead of cancelling it permanently.
+			if ( self::getOrderService()->orderContainsSubscription( $order ) ) {
+				$order->update_status(
+					OrderService::WC_STATUS_FAILED,
+					__( 'Payment not received within 15 minutes (Payrexx).' )
+				);
+				return;
+			}
+
 			$order->update_status(
 				'cancelled',
 				__( 'Automatically cancelled – payment not received within 15 minutes (Payrexx).')


### PR DESCRIPTION
**Problem:**

A failed or expired payment on a WooCommerce Subscriptions order was mapped to the WC order status `cancelled`. WC Subscriptions treats `cancelled` as a *permanent* cancellation, whereas `failed` puts the subscription on-hold and enables the failed-payment retry. As a result a declined/expired subscription payment permanently cancelled the customer's subscription, with no retry.

Three code paths set a subscription-linked order to `cancelled` on a failed/abandoned payment:

1. **Webhook mapping** — `OrderService::handleTransactionStatus()` mapped `DECLINED`/`EXPIRED` → `WC_STATUS_CANCELLED` (only `ERROR` → `failed`).
2. **Redirect return** — `PaymentHelper::handleError()` set the order to `cancelled` when the customer returned after a terminal failure. It runs synchronously and wins the race against the async webhook (`transition_allowed()` only permits `failed`/`cancelled` from `pending`/`on-hold`, so whichever fires first sticks).
3. **Unpaid-order timeout (~15 min)** — `payrexx_auto_cancel_unpaid_order()` hard-cancelled pending orders, e.g. an abandoned manual renewal.

Note on the original report: an inline card decline does **not** immediately redirect the customer back to WooCommerce — Payrexx keeps them on the payment page to retry (verified locally). `failedRedirectUrl == cancelRedirectUrl` is therefore not the driver, and dropping `failedRedirectUrl` was rejected: the result-page retry logic is VPOS-only, so removing it would strand e-commerce customers on a failed page with no retry.

**Fix:**

All three paths now map to `failed` **only when the order belongs to a subscription** (`wcs_order_contains_subscription($order, 'any')`, guarded by `function_exists`); non-subscription orders keep the existing `cancelled` behaviour. `CANCELLED` (deliberate abort) always stays `cancelled`.

- `OrderService`: `DECLINED`/`EXPIRED` → `failed` for subscription orders; new `orderContainsSubscription()` helper.
- `PaymentHelper::handleError()`: `failed` for subscription orders — closes the race that would otherwise block the webhook fix.
- `payrexx_auto_cancel_unpaid_order()`: `failed` for subscription orders.

Subscription-scoped, not global, on purpose: for normal orders `cancelled` triggers WC stock release (`wc_maybe_increase_stock_levels`) and the booking-recovery hook (`cancelled_to_processing`); `failed` has no stock-increase hook, so a global change would leak stock on every expired on-hold order. Subscription orders do not hit those paths.

**Verified:**

- New standalone test `tests/OrderServiceStatusMappingTest.php` (11 cases) — DECLINED/EXPIRED + subscription → `failed`; CANCELLED and all non-subscription cases → `cancelled` unchanged; ERROR/WAITING regressions; `transition_allowed` gate. 11/11 pass.
- E2E on a local WooCommerce without WC Subscriptions: DECLINED, timeout and handleError on a non-subscription order all still resolve to `cancelled` (byte-identical to current behaviour; the `function_exists` guard produces no fatal).
- `php -l` clean on all three changed files.

**Note:** Closes #62